### PR TITLE
Add support for overriding chart version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -78,6 +78,7 @@ that the correct docker image is used. An example snippet:
 |Property |Default |Description
 
 |chartName |The Maven `artifactId` |The name of the chart
+|chartVersion |`"${project.model.version}"` |The version of the chart
 |chartRepoUrl |`"https://kubernetes-helm.storage.googleapis.com/"` |The URL of the Chart repository where dependencies are required from and where charts should be published to
 |chartRepoUsername |None |The username for basic authentication against the chart repo
 |chartRepoPassword |None |The password for basic authentication against the chart repo

--- a/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
@@ -51,6 +51,9 @@ abstract class AbstractHelmMojo : AbstractMojo() {
 	@Parameter(property = "helmDownloadUrl", defaultValue = "https://kubernetes-helm.storage.googleapis.com/")
 	private lateinit var helmDownloadUrl: URI
 
+	@Parameter(property = "chartVersion", required = false, defaultValue = "\${project.model.version}")
+	protected lateinit var chartVersion: String
+
 	@Parameter(defaultValue = "\${project}", readonly = true, required = true)
 	protected lateinit var project: MavenProject
 
@@ -118,7 +121,7 @@ abstract class AbstractHelmMojo : AbstractMojo() {
 
 	protected fun target() = File(project.build.directory).resolve("helm")
 
-	protected fun chartTarGzFile() = target().resolve("${chartName()}-${project.version}.tgz")
+	protected fun chartTarGzFile() = target().resolve("${chartName()}-${chartVersion}.tgz")
 
 	protected fun chartName(): String = chartName ?: project.artifactId
 

--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -71,7 +71,7 @@ class PackageMojo : AbstractHelmMojo() {
 			executeCmd("$helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com")
 			executeCmd("$helm repo add chartRepo $chartRepoUrl")
 			executeCmd("$helm dependency update", directory = targetHelmDir)
-			executeCmd("$helm package ${chartName()} --version ${project.model.version}")
+			executeCmd("$helm package ${chartName()} --version $chartVersion")
 
 			ensureChartFileExists()
 


### PR DESCRIPTION
With regard to issue https://github.com/deviceinsight/helm-maven-plugin/issues/7

Since --version flag overrides the version in Chart.yaml and also sets the version in the package file name, I couldn't find any use-case where I would prefer to set version in Chart.yaml and not use the --version flag explicitly.

That being said, I've added a new param (chartVersion) which is used as the --version flag value and its default value is ${project.model.version} for backward compatibility.

I also updated the README accordingly. 