### PR TITLE
More flexibility in Deploy Mojo

### DIFF
--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -134,6 +134,7 @@ class PackageMojo : AbstractHelmMojo() {
 		return when (property) {
 			"project.version" -> project.version
 			"artifactId" -> project.artifactId
+			in System.getProperties().keys -> System.getProperty(property)
 			else -> project.properties.getProperty(property)
 		}
 	}


### PR DESCRIPTION
- closes #20 
- Added chartDeployMethod which will allow to use it with JFrog Artifactory (PUT)
- Using chartRepoUrl fully instead of constructing on the fly
- Fix a bug that system properties not propagated during templating