### PR TITLE
Fix package when binary files present

### DIFF
--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -30,6 +30,7 @@ class PackageMojo : AbstractHelmMojo() {
 
 	companion object {
 		private val PLACEHOLDER_REGEX = Regex("""\$\{(.*)}""")
+		private val SUBSTITUTED_EXTENSIONS = setOf("json", "tpl", "yml", "yaml")
 	}
 
 	@Parameter(property = "chartRepoUrl", required = false)
@@ -116,6 +117,11 @@ class PackageMojo : AbstractHelmMojo() {
 			log.debug("Copying to ${targetFile.absolutePath}")
 			targetFile.apply {
 				parentFile.mkdirs()
+			}
+
+			if (!SUBSTITUTED_EXTENSIONS.contains(file.extension)) {
+				file.copyTo(targetFile, true)
+				return@onEach
 			}
 
 			targetFile.bufferedWriter().use { writer ->


### PR DESCRIPTION
Fixes #40 by only processing extensions json, tpl, yml and yaml. Binary files (or any file not in whitelisted extensions) are still copied, they're just not treated as text files and don't attempt property substitution.