### PR TITLE
Fix multi-variable strings processing in chart files

### DIFF
--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -29,7 +29,7 @@ import java.io.File
 class PackageMojo : AbstractHelmMojo() {
 
 	companion object {
-		private val PLACEHOLDER_REGEX = Regex("""\$\{(.*)}""")
+		private val PLACEHOLDER_REGEX = Regex("""\$\{(.*?)\}""")
 	}
 
 	@Parameter(property = "chartRepoUrl", required = false)


### PR DESCRIPTION
Hello! 

I've been desperately looking for some Maven plugin to handle Helm charts and it looks like that this one does exactly what I expect it to do (similar to https://github.com/unbroken-dome/gradle-helm-plugin/ for Gradle).

I've came across of the issue that there is only a single placeholder in the line that can be substituted by the build process. However, there are cases, when it's highly possible to have multiple variables in the same line, e.g.:

```yaml
image:
    repository: ${artifactoryDockerRepo}.${artifactoryDomain}/${teamPrefix} 
    name: ${imageName}
    tag: ${project.version}
    pullPolicy: Always
```

So, using the current release it is not getting replaced as it is not detected by the regex. I fixed the regex to be non-greedy and capture as many variables as present.