### PR TITLE
Add new setting to overwrite default helm stable version for helm in…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,5 +1,9 @@
 = Changelog
 
+== Unreleased
+* Support configuring the default URL of the helm repository for helm 2.x via `stableRepoUrl`
+
+
 == Version 2.8.1
 
 * Fix detection of aarch64/arm64 architecture

--- a/README.adoc
+++ b/README.adoc
@@ -94,6 +94,7 @@ that the correct docker image is used. An example snippet:
 |helmVersion |None |The helm binary `version`. (Make sure to use a recent helm binary version that doesn't use the old Helm Chart repositories from `+https://kubernetes-charts.storage.googleapis.com+`, >= 3.4.0 _or_ >= 2.17.0 if you are still using Helm 2)
 |helmDownloadUrl |`"https://get.helm.sh/"` |The URL where the helm binary is downloaded from.
 |helm.skip |`false` |If true, execution will be skipped entirely
+|stableRepoUrl | `"https://charts.helm.sh/stable"` | For helm 2.x: Can be used to overwrite the default URL for stable repository during `helm init`
 |strictLint |`false` |If true, linting fails on warnings (see: <<goal-lint>>)
 |valuesFile | None | values file that should be used for goals <<goal-lint>>, <<goal-template>>
 |outputFile | target/test-classes/helm.yaml | output file for <<goal-template,template goal>>

--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -48,6 +48,9 @@ class PackageMojo : AbstractHelmMojo() {
 	@Parameter(property = "incubatorRepoUrl", defaultValue = "https://charts.helm.sh/incubator")
 	private var incubatorRepoUrl: String = "https://charts.helm.sh/incubator"
 
+	@Parameter(property = "stableRepoUrl", defaultValue = "https://charts.helm.sh/stable")
+	private var stableRepoUrl: String = "https://charts.helm.sh/stable"
+
 	@Parameter(property = "addIncubatorRepo", defaultValue = "true")
 	private var addIncubatorRepo: Boolean = true
 
@@ -80,7 +83,7 @@ class PackageMojo : AbstractHelmMojo() {
 			processHelmConfigFiles(targetHelmDir)
 
 			if (majorHelmVersion() < 3) {
-				executeCmd("$helm init --client-only")
+				executeCmd("$helm init --client-only --stable-repo-url $stableRepoUrl")
 			}
 
 			if (addIncubatorRepo) {


### PR DESCRIPTION
…it 2.x

A helm init in version helm 2.x adds a default repo url ('--stable-repo-url'), which leads on a isolated environment to the issue, that the default is not availalbe. With the new setting, this can be overwritten, default is still "https://charts.helm.sh/stable"