### PR TITLE
Add support for authenticating using maven's settings.xml server credentials

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,8 @@
 
 == Unreleased
 
+* Support authentication to the helm repository using credentials from server definitions in maven `settings.xml` via `chartRepoServerId`.
+
 == Version 2.10.0
 
 * Add a new goal, `resolve`, for downloading the helm binary as a separate step. This will still be done automatically

--- a/README.adoc
+++ b/README.adoc
@@ -87,6 +87,7 @@ that the correct docker image is used. An example snippet:
 |chartDeleteUrl |`${chartRepoUrl}/api/charts/${chartName}/${chartVersion}` |The URL that will be used for deleting a previous version of the chart. This is used for updating SNAPSHOT versions. The default value will work if `chartRepoUrl` refers to a ChartMuseum.
 |chartRepoUsername |None |The username for basic authentication against the chart repo
 |chartRepoPassword |None |The password for basic authentication against the chart repo
+|chartRepoServerId |None |The ID of the server definition from the settings.xml server list to obtain the chart repo username/password from. If both chartRepoUsername/chartRepoPassword and chartRepoServerId are specified then the values specified in chartRepoUsername/chartRepoPassword take precedence.
 |chartFolder |`"src/main/helm/<chartName>"` |The location of the chart files (e.g. Chart.yaml).
 |skipSnapshots |`true` |If true, SNAPSHOT versions will be built, but not deployed.
 |helmGroupId |`"com.deviceinsight.helm"` |The helm binary `groupId`

--- a/src/main/kotlin/com/deviceinsight/helm/util/ServerAuthentication.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/util/ServerAuthentication.kt
@@ -1,0 +1,35 @@
+package com.deviceinsight.helm.util
+
+import org.apache.maven.plugin.logging.Log
+import org.apache.maven.settings.Server
+import org.apache.maven.settings.Settings
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher
+import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException
+
+interface ServerAuthentication {
+
+	val settings: Settings
+	val securityDispatcher: SecDispatcher
+
+	fun getLog(): Log
+
+	fun getServer(chartRepoServerId: String?): Server? {
+		if (chartRepoServerId != null) {
+			val server = settings.getServer(chartRepoServerId)
+
+			if (server != null) {
+				return server
+			}
+
+			getLog().warn("No server definition found for $chartRepoServerId in the maven settings.xml server list.")
+		}
+
+		return null
+	}
+
+	@Throws(SecDispatcherException::class)
+	fun decryptPassword(password: String?): String? {
+		return if (password != null) securityDispatcher.decrypt(password) else null
+	}
+
+}


### PR DESCRIPTION
Adds a new configuration parameter - `chartRepoServerId` - which can be used to specify the ID of the server definition from maven's settings.xml. When specified the credentials from the server definition are used to authenticate to the helm chart repository.  If both `chartRepoUsername`/`chartRepoPassword` and `chartRepoServerId` are specified then the values specified in `chartRepoUsername`/`chartRepoPassword` take precedence.