### PR TITLE
Fix dokka configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
 									</sourceDirectories>
 									<perPackageOptions>
 										<packageOptions>
-											<prefix>com.deviceinsight.helm</prefix>
+											<matchingRegex>com\.deviceinsight\.helm\..*</matchingRegex>
 											<reportUndocumented>false</reportUndocumented>
 										</packageOptions>
 									</perPackageOptions>


### PR DESCRIPTION
Replace the removed option "prefix" with the corresponding regex.