### PR TITLE
Always pass `--force-update` when adding helm repositories managed by this plugin

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,6 +3,7 @@
 == Unreleased
 
 * Support authentication to the helm repository using credentials from server definitions in maven `settings.xml` via `chartRepoServerId`.
+* Always pass `--force-update` when adding helm repositories managed by this plugin.
 
 == Version 2.10.0
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -3,7 +3,7 @@
 == Unreleased
 
 * Support authentication to the helm repository using credentials from server definitions in maven `settings.xml` via `chartRepoServerId`.
-* Always pass `--force-update` when adding helm repositories managed by this plugin.
+* Add an option to pass `--force-update` when adding helm repositories managed by this plugin.
 
 == Version 2.10.0
 

--- a/README.adoc
+++ b/README.adoc
@@ -82,6 +82,7 @@ that the correct docker image is used. An example snippet:
 |chartRepoUrl |`null` |The URL of the Chart repository where dependencies are required from and where charts should be published to
 |incubatorRepoUrl |`https://charts.helm.sh/incubator` |The URL to the incubator Chart repository
 |addIncubatorRepo |`true` |Whether the repository defined in `incubatorRepoUrl` should be added when running the package goal
+|forceAddRepos |`false` |Whether to overwrite the repository configuration when adding a new repository with the same name. This flag is only relevant when using Helm 3 and emulates Helm 2 behavior
 |chartPublishUrl |`${chartRepoUrl}/api/charts` |The URL that will be used for publishing the chart. The default value will work if `chartRepoUrl` refers to a ChartMuseum.
 |chartPublishMethod |"POST" |The HTTP method that will be used for publishing requests
 |chartDeleteUrl |`${chartRepoUrl}/api/charts/${chartName}/${chartVersion}` |The URL that will be used for deleting a previous version of the chart. This is used for updating SNAPSHOT versions. The default value will work if `chartRepoUrl` refers to a ChartMuseum.

--- a/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
@@ -42,6 +42,7 @@ abstract class AbstractHelmMojo : AbstractMojo() {
 	protected fun executeCmd(
 		cmd: List<String>,
 		directory: File = target(),
+		logStdoutToInfo: Boolean = false,
 		redirectOutput: ProcessBuilder.Redirect = ProcessBuilder.Redirect.PIPE
 	) {
 		val proc = ProcessBuilder(cmd)
@@ -51,7 +52,8 @@ abstract class AbstractHelmMojo : AbstractMojo() {
 			.start()
 
 		val stdoutPrinter = thread(name = "Stdout printer") {
-			proc.inputStream.bufferedReader().lines().forEach { log.debug("Output: $it") }
+			val logFunction: (String) -> Unit = if (logStdoutToInfo) log::info else log::debug
+			proc.inputStream.bufferedReader().lines().forEach { logFunction("Output: $it") }
 		}
 
 		val stderrPrinter = thread(name = "Stderr printer") {

--- a/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
@@ -38,9 +38,12 @@ abstract class AbstractHelmMojo : AbstractMojo() {
 	@Parameter(property = "chartName", required = false)
 	private var chartName: String? = null
 
-	protected fun executeCmd(cmd: String, directory: File = target(),
-							 redirectOutput: ProcessBuilder.Redirect = ProcessBuilder.Redirect.PIPE) {
-		val proc = ProcessBuilder(cmd.split(" "))
+	protected fun executeCmd(
+		vararg cmd: String,
+		directory: File = target(),
+		redirectOutput: ProcessBuilder.Redirect = ProcessBuilder.Redirect.PIPE
+	) {
+		val proc = ProcessBuilder(cmd.toList())
 			.directory(directory)
 			.redirectOutput(redirectOutput)
 			.redirectError(ProcessBuilder.Redirect.PIPE)
@@ -48,7 +51,7 @@ abstract class AbstractHelmMojo : AbstractMojo() {
 
 		proc.waitFor()
 
-		log.debug("When executing '$cmd' in '${directory.absolutePath}', result was ${proc.exitValue()}")
+		log.debug("When executing '${cmd.toList()}' in '${directory.absolutePath}', result was ${proc.exitValue()}")
 		proc.inputStream.bufferedReader().lines().forEach { log.debug("Output: $it") }
 		proc.errorStream.bufferedReader().lines().forEach { log.error("Output: $it") }
 

--- a/src/main/kotlin/com/deviceinsight/helm/LintMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/LintMojo.kt
@@ -65,7 +65,7 @@ class LintMojo : ResolveHelmMojo() {
 				command.add(quoteFilePath(project.basedir.resolve(valuesFile!!).absolutePath))
 			}
 
-			executeCmd(command)
+			executeCmd(command, logStdoutToInfo = true)
 
 		} catch (e: Exception) {
 			throw MojoExecutionException("Error rendering helm lint: ${e.message}", e)

--- a/src/main/kotlin/com/deviceinsight/helm/LintMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/LintMojo.kt
@@ -20,7 +20,6 @@ import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.plugins.annotations.LifecyclePhase
 import org.apache.maven.plugins.annotations.Mojo
 import org.apache.maven.plugins.annotations.Parameter
-import java.io.File
 
 
 @Mojo(name = "lint", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST)
@@ -66,31 +65,10 @@ class LintMojo : ResolveHelmMojo() {
 				command.add(quoteFilePath(project.basedir.resolve(valuesFile!!).absolutePath))
 			}
 
-			executeCommand(command)
+			executeCmd(command)
 
 		} catch (e: Exception) {
 			throw MojoExecutionException("Error rendering helm lint: ${e.message}", e)
-		}
-	}
-
-	private fun executeCommand(command: List<String>, directory: File = target()) {
-		val proc = ProcessBuilder(command)
-			.directory(directory)
-			.redirectOutput(ProcessBuilder.Redirect.PIPE)
-			.redirectErrorStream(true)
-			.start()
-
-		proc.waitFor()
-
-		log.debug("When executing '${command.joinToString(" ")}' in '${directory.absolutePath}', " +
-			"result was ${proc.exitValue()}")
-		proc.inputStream.bufferedReader().lines().forEach {
-			log.info("Output: $it")
-		}
-
-		if (proc.exitValue() != 0) {
-			throw RuntimeException(
-				"When executing '${command.joinToString(" ")}' got result code '${proc.exitValue()}'")
 		}
 	}
 }

--- a/src/main/kotlin/com/deviceinsight/helm/TemplateMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/TemplateMojo.kt
@@ -59,9 +59,9 @@ class TemplateMojo : ResolveHelmMojo() {
 
 			val command = if (valuesFile != null) {
 				val valuesFilePath = project.basedir.resolve(valuesFile!!).absolutePath
-				arrayOf(helm, "template", "--values", valuesFilePath, chartName())
+				listOf(helm, "template", "--values", valuesFilePath, chartName())
 			} else {
-				arrayOf(helm, "template", chartName())
+				listOf(helm, "template", chartName())
 			}
 
 			var file = File(outputFile)
@@ -73,7 +73,7 @@ class TemplateMojo : ResolveHelmMojo() {
 				file.parentFile.mkdirs()
 			}
 
-			executeCmd(*command, redirectOutput = ProcessBuilder.Redirect.to(file))
+			executeCmd(command, redirectOutput = ProcessBuilder.Redirect.to(file))
 
 			log.info("Rendered helm template to '${file.absolutePath}'")
 

--- a/src/main/kotlin/com/deviceinsight/helm/TemplateMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/TemplateMojo.kt
@@ -59,9 +59,9 @@ class TemplateMojo : ResolveHelmMojo() {
 
 			val command = if (valuesFile != null) {
 				val valuesFilePath = project.basedir.resolve(valuesFile!!).absolutePath
-				"$helm template --values ${quoteFilePath(valuesFilePath)} ${chartName()}"
+				arrayOf(helm, "template", "--values", valuesFilePath, chartName())
 			} else {
-				"$helm template ${chartName()}"
+				arrayOf(helm, "template", chartName())
 			}
 
 			var file = File(outputFile)
@@ -73,7 +73,7 @@ class TemplateMojo : ResolveHelmMojo() {
 				file.parentFile.mkdirs()
 			}
 
-			executeCmd(command, redirectOutput = ProcessBuilder.Redirect.to(file))
+			executeCmd(*command, redirectOutput = ProcessBuilder.Redirect.to(file))
 
 			log.info("Rendered helm template to '${file.absolutePath}'")
 


### PR DESCRIPTION
When Helm 3 is detected, `--force-update` is always passed to `helm repo add`. This restores the behavior that Helm 2 had.

Also, clean up `executeCmd()` a bit. This makes it easier to pass optional arguments and also prevents the smuggling of arguments via the repo URLs.

Closes #94, Closes #84