### PR TITLE
Cleanup dependencies, readme, and deprecated Kotlin functions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,6 +4,7 @@
 
 * Support authentication to the helm repository using credentials from server definitions in maven `settings.xml` via `chartRepoServerId`.
 * Add an option to pass `--force-update` when adding helm repositories managed by this plugin.
+* Cleanup dependencies, readme, and deprecated Kotlin functions
 
 == Version 2.10.0
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 = Helm Maven Plugin
 
-:uri-build-status: https://travis-ci.org/deviceinsight/helm-maven-plugin
-:img-build-status: https://api.travis-ci.org/deviceinsight/helm-maven-plugin.svg?branch=develop
+:uri-build-status: https://github.com/deviceinsight/helm-maven-plugin/actions/workflows/maven.yml
+:img-build-status: https://github.com/deviceinsight/helm-maven-plugin/actions/workflows/maven.yml/badge.svg
 
 image:{img-build-status}[Build Status Badge,link={uri-build-status}]
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,9 @@
 
 		<maven.version>3.6.2</maven.version>
 		<maven-project.version>2.2.1</maven-project.version>
-		<maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
 
-		<jackson.version>2.14.2</jackson.version>
 		<httpclient.version>4.5.14</httpclient.version>
+		<plexus-sec-dispatcher.version>1.4</plexus-sec-dispatcher.version>
 
 		<junit.jupiter.version>5.9.2</junit.jupiter.version>
 		<assertj-core.version>3.24.2</assertj-core.version>
@@ -45,13 +44,6 @@
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson</groupId>
-				<artifactId>jackson-bom</artifactId>
-				<version>${jackson.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -65,6 +57,7 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>${maven.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
@@ -76,44 +69,30 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-artifact</artifactId>
 			<version>${maven.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<version>${maven.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-project</artifactId>
 			<version>${maven-project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven.shared</groupId>
-			<artifactId>maven-artifact-transfer</artifactId>
-			<version>${maven-artifact-transfer.version}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
-			<artifactId>jackson-annotations</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.dataformat</groupId>
-			<artifactId>jackson-dataformat-yaml</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.module</groupId>
-			<artifactId>jackson-module-kotlin</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<version>${httpclient.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.sonatype.plexus</groupId>
+			<artifactId>plexus-sec-dispatcher</artifactId>
+			<version>${plexus-sec-dispatcher.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -154,7 +154,7 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 				parentFile.mkdirs()
 			}
 
-			if (!SUBSTITUTED_EXTENSIONS.contains(file.extension.toLowerCase())) {
+			if (!SUBSTITUTED_EXTENSIONS.contains(file.extension.lowercase())) {
 				file.copyTo(targetFile, true)
 				return@onEach
 			}
@@ -171,7 +171,7 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 							}
 						}
 					}.forEach {
-						writer.appendln(it)
+						writer.appendLine(it)
 					}
 				}
 			}

--- a/src/main/kotlin/com/deviceinsight/helm/util/PlatformDetector.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/util/PlatformDetector.kt
@@ -52,7 +52,7 @@ object PlatformDetector {
 	}
 
 	private fun normalizeIdentifier(identifier: String): String {
-		return identifier.toLowerCase(Locale.US).replace(IGNORED_CHARACTERS, "")
+		return identifier.lowercase(Locale.US).replace(IGNORED_CHARACTERS, "")
 	}
 
 }


### PR DESCRIPTION
The PR removed some unused dependencies, fixes the CI icon in the readme, and replaces deprecated Kotlin functions.

```
Maven dependencies of Maven Plugins should be in provided scope.
Please make sure that all your dependencies declared in POM whose group ID is
org.apache.maven have set '<scope>provided</scope>' as well.
In the future this error will break the build.

The following dependencies are in wrong scope:
 * org.apache.maven:maven-model:jar:3.6.2:compile
 * org.apache.maven:maven-settings:jar:3.6.2:compile
 * org.apache.maven:maven-repository-metadata:jar:3.6.2:compile
 * org.apache.maven:maven-project:jar:2.2.1:compile
 * org.apache.maven:maven-profile:jar:2.2.1:compile
 * org.apache.maven:maven-artifact-manager:jar:2.2.1:compile
 * org.apache.maven:maven-plugin-registry:jar:2.2.1:compile

Please fix your build!
```