### PR TITLE
add option to provide additional values files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Converted README and CHANGELOG to Markdown
+* Add option to provide additional values files
 
 ## Version 2.11.1
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ that the correct docker image is used. An example snippet:
 | stableRepoUrl | `"https://charts.helm.sh/stable"` | For helm 2.x: Can be used to overwrite the default URL for stable repository during `helm init` |
 | strictLint | `false` | If true, linting fails on warnings (see: [Lint](#lint)) |
 | valuesFile | None | values file that should be used for goals [Lint](#lint), [Template](#template) |
+| extraValuesFiles | None | a list of additional values files that can be generated dynamically and will be merged with the values.yaml during [Package](#package). |
 | outputFile | target/test-classes/helm.yaml | output file for [template goal](#template) |
 | deployAtEnd | `false` | If true, the helm chart is deployed at the end of a multi-module Maven build. This option does not make sense for single-module Maven projects. |
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 		<maven.version>3.6.2</maven.version>
 		<maven-project.version>2.2.1</maven-project.version>
 
+		<jackson-bom.version>2.14.2</jackson-bom.version>
 		<httpclient.version>4.5.14</httpclient.version>
 		<plexus-sec-dispatcher.version>1.4</plexus-sec-dispatcher.version>
 
@@ -43,6 +44,13 @@
 				<version>${kotlin.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson</groupId>
+				<artifactId>jackson-bom</artifactId>
+				<version>${jackson-bom.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -93,6 +101,15 @@
 			<groupId>org.sonatype.plexus</groupId>
 			<artifactId>plexus-sec-dispatcher</artifactId>
 			<version>${plexus-sec-dispatcher.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -199,7 +199,7 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 			return
 		}
 
-		val missingFiles = extraValuesFiles.filter { !File(it).exists() }.toList()
+		val missingFiles = extraValuesFiles.filter { !File(it).exists() }
 		if (missingFiles.isNotEmpty()) {
 			throw IllegalStateException("extraValueFiles not found: $missingFiles")
 		}

--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -17,6 +17,10 @@
 package com.deviceinsight.helm
 
 import com.deviceinsight.helm.util.ServerAuthentication
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
 import org.apache.maven.plugin.MojoExecutionException
 import org.apache.maven.plugins.annotations.Component
 import org.apache.maven.plugins.annotations.LifecyclePhase
@@ -25,6 +29,8 @@ import org.apache.maven.plugins.annotations.Parameter
 import org.apache.maven.settings.Settings
 import org.sonatype.plexus.components.sec.dispatcher.SecDispatcher
 import java.io.File
+import java.io.IOException
+
 
 /**
  * Packages helm charts
@@ -70,6 +76,9 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 	@Parameter(defaultValue = "\${settings}", readonly = true)
 	override lateinit var settings: Settings
 
+	@Parameter(property = "extraValuesFiles")
+	private val extraValuesFiles: List<String> = emptyList()
+
 	@Throws(MojoExecutionException::class)
 	override fun execute() {
 
@@ -98,6 +107,7 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 			log.info("Created target helm directory")
 
 			processHelmConfigFiles(targetHelmDir)
+			mergeValuesFiles(targetHelmDir, extraValuesFiles)
 
 			val helmAddFlags = if (isHelm2 || !forceAddRepos) emptyList() else listOf("--force-update")
 
@@ -180,6 +190,38 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 
 		if (processedFiles.isEmpty()) {
 			throw IllegalStateException("No helm files found in ${directory.absolutePath}")
+		}
+	}
+
+	private fun mergeValuesFiles(targetHelmDir: File, extraValuesFiles: List<String>) {
+
+		if (extraValuesFiles.isEmpty()) {
+			return
+		}
+
+		val missingFiles = extraValuesFiles.filter { !File(it).exists() }.toList()
+		if (missingFiles.isNotEmpty()) {
+			throw IllegalStateException("extraValueFiles not found: $missingFiles")
+		}
+
+		val allValuesFiles = extraValuesFiles.toMutableList()
+		val valuesFile = targetHelmDir.resolve("values.yaml")
+
+		if (valuesFile.exists()) {
+			allValuesFiles.add(0, valuesFile.absolutePath)
+		}
+
+		val yamlMapper = ObjectMapper(YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES))
+		val values: ObjectNode = yamlMapper.createObjectNode()
+		val yamlReader = yamlMapper.setDefaultMergeable(true).readerForUpdating(values)
+
+		try {
+			for (file in allValuesFiles) {
+				yamlReader.readValue(File(file), ObjectNode::class.java)
+			}
+			yamlMapper.writeValue(valuesFile, values)
+		} catch (e: IOException) {
+			throw RuntimeException(e)
 		}
 	}
 


### PR DESCRIPTION
This PR allows to configure additional values files:
```
<plugin>
<groupId>com.deviceinsight.helm</groupId>
<artifactId>helm-maven-plugin</artifactId>
<configuration>
        ...
	<extraValuesFiles>
		<extraValuesFile>${project.build.directory}/values-a.yaml</extraValuesFile>
		<extraValuesFile>${project.build.directory}/values-b.yaml</extraValuesFile>
	</extraValuesFiles>
</configuration>
</plugin>
```

These values will be merged together with the "main" values file (`src/main/helm/values.yaml`) during packaging of the helm chart.

## Why is this needed?

This feature is useful, when you have parts of `values.yaml` which are dynamically generated. In our case these are generated by a different maven plugin.

## Disadvantages

When using this feature, the resulting `values.yaml` will no longer contain comments.
The parsing processing will strip those. But I guess there are not that many situations where you want to look at the comments of the `values.yaml` inside the packaged chart.
Other than that, the resulting yaml looks fairly similar.

## Non-breaking

The feature should not introduce any breaking changes into existing behavior. When the `extraValuesFiles` configuration is not used, the plugin works as before.
