### PR TITLE
Remove Helm 2 support, add integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ develop, master ]
   pull_request:
-    branches: [ develop ]
+    branches: [ develop, v3 ]
 
 jobs:
   build_jdk11:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,7 +2,7 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop, master, v3 ]
   pull_request:
     branches: [ develop, v3 ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
 		<gitflow-maven-plugin.version>1.19.0</gitflow-maven-plugin.version>
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
 		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-		<maven-invoker-plugin.version>3.3.0</maven-invoker-plugin.version>
-		<maven-invoker-plugin.groovy.version>4.0.6</maven-invoker-plugin.groovy.version>
+		<maven-invoker-plugin.version>3.5.0</maven-invoker-plugin.version>
+		<maven-invoker-plugin.groovy.version>4.0.10</maven-invoker-plugin.groovy.version>
 	</properties>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -12,28 +12,30 @@
 	<url>https://github.com/deviceinsight/helm-maven-plugin</url>
 
 	<properties>
+		<!-- Compiler -->
 		<kotlin.version>1.8.10</kotlin.version>
 		<kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+		<!-- Maven -->
 		<maven.version>3.6.2</maven.version>
-		<maven-project.version>2.2.1</maven-project.version>
+		<maven-plugin-tools.version>3.8.1</maven-plugin-tools.version>
 
+		<!-- Project dependencies -->
 		<jackson-bom.version>2.14.2</jackson-bom.version>
 		<httpclient.version>4.5.14</httpclient.version>
 		<plexus-sec-dispatcher.version>1.4</plexus-sec-dispatcher.version>
 
-		<junit.jupiter.version>5.9.2</junit.jupiter.version>
-		<assertj-core.version>3.24.2</assertj-core.version>
-
-		<dokka-maven-plugin.version>1.7.20</dokka-maven-plugin.version>
+		<!-- Plugins -->
 		<maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
 		<maven-source-plugin.version>3.2.1</maven-source-plugin.version>
 		<gitflow-maven-plugin.version>1.19.0</gitflow-maven-plugin.version>
 		<nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
 		<maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+		<maven-invoker-plugin.version>3.3.0</maven-invoker-plugin.version>
+		<maven-invoker-plugin.groovy.version>4.0.6</maven-invoker-plugin.groovy.version>
 	</properties>
 
 	<dependencyManagement>
@@ -68,27 +70,15 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven.plugin-tools</groupId>
-			<artifactId>maven-plugin-annotations</artifactId>
-			<version>${maven.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-artifact</artifactId>
-			<version>${maven.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<version>${maven.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven-project.version}</version>
+			<groupId>org.apache.maven.plugin-tools</groupId>
+			<artifactId>maven-plugin-annotations</artifactId>
+			<version>${maven-plugin-tools.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -102,7 +92,6 @@
 			<artifactId>plexus-sec-dispatcher</artifactId>
 			<version>${plexus-sec-dispatcher.version}</version>
 		</dependency>
-
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
@@ -110,25 +99,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.assertj</groupId>
-			<artifactId>assertj-core</artifactId>
-			<version>${assertj-core.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.jetbrains.kotlin</groupId>
-			<artifactId>kotlin-test-junit</artifactId>
-			<version>${kotlin.version}</version>
-			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -161,7 +131,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>${maven.version}</version>
+				<version>${maven-plugin-tools.version}</version>
 				<configuration>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
 					<goalPrefix>helm</goalPrefix>
@@ -220,21 +190,37 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.jetbrains.dokka</groupId>
-				<artifactId>dokka-maven-plugin</artifactId>
-				<version>${dokka-maven-plugin.version}</version>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-invoker-plugin</artifactId>
+				<version>${maven-invoker-plugin.version}</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.groovy</groupId>
+						<artifactId>groovy</artifactId>
+						<version>${maven-invoker-plugin.groovy.version}</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<projectsDirectory>src/test/it</projectsDirectory>
+					<showErrors>true</showErrors>
+					<cloneProjectsTo>${project.build.directory}/its</cloneProjectsTo>
+					<pomIncludes>
+						<pomInclude>*/pom.xml</pomInclude>
+					</pomIncludes>
+					<settingsFile>src/test/it/settings.xml</settingsFile>
+					<localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+					<postBuildHookScript>verify.groovy</postBuildHookScript>
+					<goals>
+						<goal>verify</goal>
+					</goals>
+				</configuration>
 				<executions>
 					<execution>
-						<phase>prepare-package</phase>
+						<phase>verify</phase>
 						<goals>
-							<goal>dokka</goal>
-							<goal>javadocJar</goal>
+							<goal>install</goal>
+							<goal>run</goal>
 						</goals>
-						<configuration>
-							<sourceDirectories>
-								<dir>${project.build.sourceDirectory}</dir>
-							</sourceDirectories>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/AbstractHelmMojo.kt
@@ -45,6 +45,16 @@ abstract class AbstractHelmMojo : AbstractMojo() {
 		logStdoutToInfo: Boolean = false,
 		redirectOutput: ProcessBuilder.Redirect = ProcessBuilder.Redirect.PIPE
 	) {
+		check(directory.exists()) {
+			val hint = if (directory == target()) {
+				"Target helm chart dir ($directory) does not exist. Did you run the 'package' goal first?"
+			} else {
+				"Working directory does not exist: $directory"
+			}
+
+			"Unable to execute '${cmd.joinToString(" ")}': $hint"
+		}
+
 		val proc = ProcessBuilder(cmd)
 			.directory(directory)
 			.redirectOutput(redirectOutput)

--- a/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/PackageMojo.kt
@@ -64,9 +64,6 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 	@Parameter(property = "incubatorRepoUrl", defaultValue = "https://charts.helm.sh/incubator")
 	private var incubatorRepoUrl: String = "https://charts.helm.sh/incubator"
 
-	@Parameter(property = "stableRepoUrl", defaultValue = "https://charts.helm.sh/stable")
-	private var stableRepoUrl: String = "https://charts.helm.sh/stable"
-
 	@Parameter(property = "addIncubatorRepo", defaultValue = "true")
 	private var addIncubatorRepo: Boolean = true
 
@@ -97,7 +94,6 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 			super.execute()
 
 			val targetHelmDir = File(target(), chartName())
-			val isHelm2 = majorHelmVersion() < 3
 
 			log.info("Clear target directory to ensure clean target package")
 			if (targetHelmDir.exists()) {
@@ -109,11 +105,8 @@ class PackageMojo : ResolveHelmMojo(), ServerAuthentication {
 			processHelmConfigFiles(targetHelmDir)
 			mergeValuesFiles(targetHelmDir, extraValuesFiles)
 
-			val helmAddFlags = if (isHelm2 || !forceAddRepos) emptyList() else listOf("--force-update")
+			val helmAddFlags = if (forceAddRepos) listOf("--force-update") else emptyList()
 
-			if (isHelm2) {
-				executeCmd(listOf(helm, "init", "--client-only", "--stable-repo-url", stableRepoUrl))
-			}
 			if (addIncubatorRepo) {
 				executeCmd(listOf(helm, "repo", "add", "incubator", incubatorRepoUrl) + helmAddFlags)
 			}

--- a/src/main/kotlin/com/deviceinsight/helm/ResolveHelmMojo.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/ResolveHelmMojo.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ open class ResolveHelmMojo : AbstractHelmMojo() {
 	@Parameter(property = "helmArtifactId", defaultValue = "helm")
 	private lateinit var helmArtifactId: String
 
-	@Parameter(property = "helmVersion", required = true)
+	@Parameter(property = "helmVersion", required = true, defaultValue = "3.11.2")
 	private lateinit var helmVersion: String
 
 	@Parameter(property = "helmDownloadUrl", defaultValue = "https://get.helm.sh/")
@@ -65,7 +65,10 @@ open class ResolveHelmMojo : AbstractHelmMojo() {
 	}
 
 	private fun checkHelmVersion() {
-		val (majorVersion, minorVersion) = helmVersion.split('.').map(String::toInt)
+		val versionPattern = """^(\d+)\.(\d+)\..*""".toRegex()
+		val matchResult = versionPattern.matchEntire(helmVersion)
+		requireNotNull(matchResult) { "Expected Helm version '$helmVersion' to match '$versionPattern'" }
+		val (majorVersion, minorVersion) = matchResult.destructured.toList().map(String::toInt)
 
 		if (majorVersion > 3) {
 			log.warn("This plugin was not tested with versions beyond Helm 3")

--- a/src/main/kotlin/com/deviceinsight/helm/util/PlatformDetector.kt
+++ b/src/main/kotlin/com/deviceinsight/helm/util/PlatformDetector.kt
@@ -16,8 +16,6 @@
 
 package com.deviceinsight.helm.util
 
-import java.util.Locale
-
 object PlatformDetector {
 
 	private val IGNORED_CHARACTERS = Regex("[^a-z0-9_]")
@@ -52,7 +50,7 @@ object PlatformDetector {
 	}
 
 	private fun normalizeIdentifier(identifier: String): String {
-		return identifier.lowercase(Locale.US).replace(IGNORED_CHARACTERS, "")
+		return identifier.lowercase().replace(IGNORED_CHARACTERS, "")
 	}
 
 }

--- a/src/test/it/it-parent.xml
+++ b/src/test/it/it-parent.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--
+  ~ Copyright 2023 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -9,17 +25,6 @@
 	<artifactId>it-parent</artifactId>
 	<version>@project.version@</version>
 	<packaging>pom</packaging>
-
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>3.8.2</version>
-				<scope>test</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<pluginManagement>

--- a/src/test/it/it-parent.xml
+++ b/src/test/it/it-parent.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.deviceinsight.helm</groupId>
+	<artifactId>it-parent</artifactId>
+	<version>@project.version@</version>
+	<packaging>pom</packaging>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>3.8.2</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>com.deviceinsight.helm</groupId>
+					<artifactId>helm-maven-plugin</artifactId>
+					<version>@project.version@</version>
+				</plugin>
+				<plugin>
+					<groupId>io.fabric8</groupId>
+					<artifactId>docker-maven-plugin</artifactId>
+					<version>0.42.0</version>
+					<configuration>
+						<removeVolumes>true</removeVolumes>
+						<logDate>ISO8601</logDate>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
+</project>

--- a/src/test/it/no-chart/pom.xml
+++ b/src/test/it/no-chart/pom.xml
@@ -1,0 +1,39 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.deviceinsight.helm</groupId>
+		<artifactId>it-parent</artifactId>
+		<version>@project.version@</version>
+		<relativePath>../it-parent.xml</relativePath>
+	</parent>
+
+	<artifactId>test</artifactId>
+
+	<description>
+		Check that package and lint steps are skipped when no chart is present
+	</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.deviceinsight.helm</groupId>
+				<artifactId>helm-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>package</goal>
+							<goal>lint</goal>
+						</goals>
+						<configuration>
+							<helmVersion>3.11.2</helmVersion>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/it/no-chart/pom.xml
+++ b/src/test/it/no-chart/pom.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2023 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -28,9 +44,6 @@
 							<goal>package</goal>
 							<goal>lint</goal>
 						</goals>
-						<configuration>
-							<helmVersion>3.11.2</helmVersion>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/src/test/it/no-chart/verify.groovy
+++ b/src/test/it/no-chart/verify.groovy
@@ -1,0 +1,4 @@
+def logLines = new File(basedir, "build.log").readLines()
+
+assert logLines.contains("[WARNING] No sources found skipping helm package.")
+assert logLines.contains("[WARNING] No sources found skipping helm lint.")

--- a/src/test/it/package-lint-template/chart/Chart.yaml
+++ b/src/test/it/package-lint-template/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: test-chart
+description: Some description
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/src/test/it/package-lint-template/chart/templates/service.yaml
+++ b/src/test/it/package-lint-template/chart/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    foo: bar

--- a/src/test/it/package-lint-template/chart/templates/service.yaml
+++ b/src/test/it/package-lint-template/chart/templates/service.yaml
@@ -3,9 +3,9 @@ kind: Service
 metadata:
   name: test-service
 spec:
-  type: { { .Values.service.type } }
+  type: {{ .Values.service.type }}
   ports:
-    - port: { { .Values.service.port } }
+    - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
       name: http

--- a/src/test/it/package-lint-template/chart/values.yaml
+++ b/src/test/it/package-lint-template/chart/values.yaml
@@ -1,0 +1,3 @@
+service:
+  type: ClusterIP
+  port: 80

--- a/src/test/it/package-lint-template/pom.xml
+++ b/src/test/it/package-lint-template/pom.xml
@@ -1,0 +1,41 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.deviceinsight.helm</groupId>
+		<artifactId>it-parent</artifactId>
+		<version>@project.version@</version>
+		<relativePath>../it-parent.xml</relativePath>
+	</parent>
+
+	<artifactId>test</artifactId>
+
+	<description>
+		Package, template and lint a chart
+	</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.deviceinsight.helm</groupId>
+				<artifactId>helm-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>package</goal>
+							<goal>lint</goal>
+							<goal>template</goal>
+						</goals>
+						<configuration>
+							<helmVersion>3.11.2</helmVersion>
+							<chartFolder>chart</chartFolder>
+							<chartName>test-chart</chartName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/it/package-lint-template/pom.xml
+++ b/src/test/it/package-lint-template/pom.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2023 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -29,7 +45,6 @@
 							<goal>template</goal>
 						</goals>
 						<configuration>
-							<helmVersion>3.11.2</helmVersion>
 							<chartFolder>chart</chartFolder>
 							<chartName>test-chart</chartName>
 						</configuration>

--- a/src/test/it/package-lint-template/verify.groovy
+++ b/src/test/it/package-lint-template/verify.groovy
@@ -1,0 +1,13 @@
+def logLines = new File(basedir, "build.log").readLines()
+
+// Package goal
+assert logLines.any { line -> line.contains("Successfully packaged chart and saved it to") }
+
+// Lint goal
+assert logLines.any { line -> line.contains("Chart.yaml: icon is recommended") }
+assert logLines.any { line -> line.contains("1 chart(s) linted, 0 chart(s) failed") }
+
+// Template goal
+def templatedChart = new File(basedir, "target/test-classes/helm.yaml")
+assert templatedChart.exists()
+assert templatedChart.readLines().contains("# Source: test-chart/templates/service.yaml")

--- a/src/test/it/package-lint-template/verify.groovy
+++ b/src/test/it/package-lint-template/verify.groovy
@@ -1,11 +1,11 @@
 def logLines = new File(basedir, "build.log").readLines()
 
 // Package goal
-assert logLines.any { line -> line.contains("Successfully packaged chart and saved it to") }
+assert logLines.any { it.contains("Successfully packaged chart and saved it to") }
 
 // Lint goal
-assert logLines.any { line -> line.contains("Chart.yaml: icon is recommended") }
-assert logLines.any { line -> line.contains("1 chart(s) linted, 0 chart(s) failed") }
+assert logLines.any { it.contains("Chart.yaml: icon is recommended") }
+assert logLines.any { it.contains("1 chart(s) linted, 0 chart(s) failed") }
 
 // Template goal
 def templatedChart = new File(basedir, "target/test-classes/helm.yaml")

--- a/src/test/it/publish-chartmuseum/dependent-chart/Chart.yaml
+++ b/src/test/it/publish-chartmuseum/dependent-chart/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: dependent-chart
+description: Some description
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+
+dependencies:
+  - name: published-chart
+    version: 0.1.0
+    repository: "@chartRepo"

--- a/src/test/it/publish-chartmuseum/pom.xml
+++ b/src/test/it/publish-chartmuseum/pom.xml
@@ -1,0 +1,106 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.deviceinsight.helm</groupId>
+		<artifactId>it-parent</artifactId>
+		<version>@project.version@</version>
+		<relativePath>../it-parent.xml</relativePath>
+	</parent>
+
+	<artifactId>test</artifactId>
+
+	<description>
+		Publish and download a chart from ChartMuseum
+	</description>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<configuration>
+					<images>
+						<image>
+							<name>ghcr.io/helm/chartmuseum:v0.14.0</name>
+							<alias>chartmuseum</alias>
+							<run>
+								<ports>
+									<port>chartmuseum.port:8080</port>
+								</ports>
+								<env>
+									<STORAGE>local</STORAGE>
+									<STORAGE_LOCAL_ROOTDIR>/tmp/charts</STORAGE_LOCAL_ROOTDIR>
+								</env>
+								<wait>
+									<log>Starting ChartMuseum</log>
+									<time>5000</time>
+								</wait>
+								<log>
+									<file>${project.build.directory}/chartmuseum.log</file>
+								</log>
+							</run>
+						</image>
+					</images>
+				</configuration>
+				<executions>
+					<execution>
+						<id>start</id>
+						<phase>prepare-package</phase>
+						<goals>
+							<goal>start</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>stop</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
+							<goal>remove</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>com.deviceinsight.helm</groupId>
+				<artifactId>helm-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>publish-chart</id>
+						<phase>package</phase>
+						<goals>
+							<goal>package</goal>
+							<goal>deploy</goal>
+						</goals>
+						<configuration>
+							<helmVersion>3.11.2</helmVersion>
+							<chartFolder>published-chart</chartFolder>
+							<chartName>published-chart</chartName>
+							<chartVersion>0.1.0</chartVersion>
+							<chartRepoUrl>http://localhost:${chartmuseum.port}/</chartRepoUrl>
+							<skipSnapshots>false</skipSnapshots>
+							<forceAddRepos>true</forceAddRepos>
+						</configuration>
+					</execution>
+					<execution>
+						<id>download-chart</id>
+						<phase>package</phase>
+						<goals>
+							<goal>package</goal>
+							<goal>deploy</goal>
+						</goals>
+						<configuration>
+							<helmVersion>3.11.2</helmVersion>
+							<chartFolder>dependent-chart</chartFolder>
+							<chartName>dependent-chart</chartName>
+							<chartRepoUrl>http://localhost:${chartmuseum.port}/</chartRepoUrl>
+							<skipSnapshots>false</skipSnapshots>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/test/it/publish-chartmuseum/pom.xml
+++ b/src/test/it/publish-chartmuseum/pom.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright 2023 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
@@ -75,7 +91,6 @@
 							<goal>deploy</goal>
 						</goals>
 						<configuration>
-							<helmVersion>3.11.2</helmVersion>
 							<chartFolder>published-chart</chartFolder>
 							<chartName>published-chart</chartName>
 							<chartVersion>0.1.0</chartVersion>
@@ -92,7 +107,6 @@
 							<goal>deploy</goal>
 						</goals>
 						<configuration>
-							<helmVersion>3.11.2</helmVersion>
 							<chartFolder>dependent-chart</chartFolder>
 							<chartName>dependent-chart</chartName>
 							<chartRepoUrl>http://localhost:${chartmuseum.port}/</chartRepoUrl>

--- a/src/test/it/publish-chartmuseum/published-chart/Chart.yaml
+++ b/src/test/it/publish-chartmuseum/published-chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: published-chart
+description: Some description
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/src/test/it/publish-chartmuseum/published-chart/templates/service.yaml
+++ b/src/test/it/publish-chartmuseum/published-chart/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  type: { { .Values.service.type } }
+  ports:
+    - port: { { .Values.service.port } }
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    foo: bar

--- a/src/test/it/publish-chartmuseum/published-chart/values.yaml
+++ b/src/test/it/publish-chartmuseum/published-chart/values.yaml
@@ -1,0 +1,3 @@
+service:
+  type: ClusterIP
+  port: 80

--- a/src/test/it/publish-chartmuseum/verify.groovy
+++ b/src/test/it/publish-chartmuseum/verify.groovy
@@ -1,0 +1,1 @@
+assert (new File(basedir, "target/helm/dependent-chart/charts/published-chart-0.1.0.tgz")).exists()

--- a/src/test/it/settings.xml
+++ b/src/test/it/settings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<settings>
+	<profiles>
+		<profile>
+			<id>it-repo</id>
+			<repositories>
+				<repository>
+					<id>local.central</id>
+					<url>@localRepositoryUrl@</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</repository>
+			</repositories>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>local.central</id>
+					<url>@localRepositoryUrl@</url>
+					<releases>
+						<enabled>true</enabled>
+					</releases>
+					<snapshots>
+						<enabled>true</enabled>
+					</snapshots>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+	</profiles>
+	<activeProfiles>
+		<activeProfile>it-repo</activeProfile>
+	</activeProfiles>
+</settings>


### PR DESCRIPTION
This is the start of a series of changes for an upcoming major release of the helm-maven-plugin.

As first PR, the support for Helm 2 is removed, unused dependencies are removed from the pom.xml and integration tests are added.