### PR TITLE
add support escaping placeholders with backslash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support escaping placeholders with backslash e.g. `\${MY_ENV_VAR}` will no longer be expanded
+
 ## Version 2.12.0
 
 * Converted README and CHANGELOG to Markdown


### PR DESCRIPTION
This PR allows to escape placeholders in order to avoid resolving them.

### Why is it needed?

```
foo:
  bar: "${CONTAINER_ENV_VAR}"
```

Currently, this already works, but a warning is shown during `package` because `CONTAINER_ENV_VAR` cannot be resolved.
With this PR we can just write the following and no longer get these warnings:


```
foo:
  bar: "\${CONTAINER_ENV_VAR}"
```
