### PR TITLE
refactoring to avoid usage of deprecated classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<maven.version>3.9.0</maven.version>
-		<maven-project.version>2.2.1</maven-project.version>
+		<maven.version>3.9.6</maven.version>
+		<maven-plugin.version>3.11.0</maven-plugin.version>
 
 		<jackson-bom.version>2.15.3</jackson-bom.version>
 		<httpclient.version>4.5.14</httpclient.version>
@@ -71,7 +71,7 @@
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>${maven.version}</version>
+			<version>${maven-plugin.version}</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -84,12 +84,6 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-core</artifactId>
 			<version>${maven.version}</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.maven</groupId>
-			<artifactId>maven-project</artifactId>
-			<version>${maven-project.version}</version>
 			<scope>provided</scope>
 		</dependency>
 
@@ -162,7 +156,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>${maven.version}</version>
+				<version>${maven-plugin.version}</version>
 				<configuration>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
 					<goalPrefix>helm</goalPrefix>
@@ -285,7 +279,7 @@
 			</roles>
 		</developer>
 		<developer>
-			<id>dwi-di</id>
+			<id>d-rk</id>
 			<name>Dirk Wilden</name>
 			<email>dirk.wilden@device-insight.com</email>
 			<roles>


### PR DESCRIPTION
Currently, you will get a warning if you use the plugin:
```
[WARNING] Parameter 'localRepository' is deprecated core expression; Avoid use of ArtifactRepository type. If you need access to local repository, switch to '${repositorySystemSession}' expression and get LRM from it instead.
```

This PR refactors the code to avoid usage of the deprecated classes.